### PR TITLE
Best effort on loading Kaldi data dir into lhotse

### DIFF
--- a/lhotse/kaldi.py
+++ b/lhotse/kaldi.py
@@ -1,0 +1,80 @@
+from collections import defaultdict
+from pathlib import Path
+from typing import Tuple, Optional
+
+from lhotse.audio import AudioSet, Recording, AudioSource
+from lhotse.supervision import SupervisionSet, SupervisionSegment
+from lhotse.utils import Pathlike
+
+
+def load_kaldi_data_dir(path: Pathlike, sampling_rate: int) -> Tuple[AudioSet, Optional[SupervisionSet]]:
+    path = Path(path)
+    assert path.is_dir()
+
+    # must exist for AudioSet
+    wav_scp = path / 'wav.scp'
+    assert wav_scp.is_file()
+    with wav_scp.open() as f:
+        recordings = dict(line.strip().split(' ', maxsplit=1) for line in f)
+
+    durations = defaultdict(float)
+    reco2dur = path / 'reco2dur'
+    if reco2dur.is_file():
+        with reco2dur.open() as f:
+            for line in f:
+                recording_id, dur = line.strip().split()
+                durations[recording_id] = float(dur)
+
+    audio_set = AudioSet({
+        recording_id: Recording(
+            id=recording_id,
+            sources=[
+                AudioSource(
+                    type='command' if path_or_cmd.endswith('|') else 'file',
+                    channel_ids=[0],
+                    source=path_or_cmd[:-1] if path_or_cmd.endswith('|') else path_or_cmd
+                )
+            ],
+            sampling_rate=sampling_rate,
+            num_samples=int(durations[recording_id] * sampling_rate),
+            duration_seconds=durations[recording_id]
+        )
+        for recording_id, path_or_cmd in recordings.items()
+    })
+
+    # must exist for SupervisionSet
+    segments = path / 'segments'
+    if not segments.is_file():
+        return audio_set, None
+
+    with segments.open() as f:
+        supervision_segments = [l.strip().split() for l in f]
+
+    texts = defaultdict(lambda: None)
+    text_path = path / 'text'
+    if text_path.is_file():
+        with text_path.open() as f:
+            texts = dict(line.strip().split(' ', maxsplit=1) for line in f)
+
+    speakers = defaultdict(lambda: None)
+    utt2spk = path / 'utt2spk'
+    if utt2spk.is_file():
+        with utt2spk.open() as f:
+            speakers = dict(line.strip().split(' ', maxsplit=1) for line in f)
+
+    # TODO: spk2gender
+
+    supervision_set = SupervisionSet({
+        segment_id: SupervisionSegment(
+            id=segment_id,
+            recording_id=recording_id,
+            start=float(start),
+            duration=float(duration),  # TODO: check again what's the second time field in segments
+            text=texts[segment_id],
+            language=None,
+            speaker=speakers[segment_id]
+        )
+        for segment_id, recording_id, start, duration in supervision_segments
+    })
+
+    return audio_set, supervision_set

--- a/lhotse/supervision.py
+++ b/lhotse/supervision.py
@@ -12,9 +12,11 @@ class SupervisionSegment:
     recording_id: str
     start: Seconds
     duration: Seconds
+    channel_id: int = 0
     text: Optional[str] = None
     language: Optional[str] = None
     speaker: Optional[str] = None
+    gender: Optional[str] = None
 
     @property
     def end(self) -> Seconds:

--- a/test/fixtures/supervision.yaml
+++ b/test/fixtures/supervision.yaml
@@ -1,6 +1,7 @@
 ---
 - id: 'segment-1'
   recording_id: 'recording-1'
+  channel_id: 0
   start: 0.1
   duration: 0.3
   text: 'transcript of the first segment'

--- a/test/test_supervision_set.py
+++ b/test/test_supervision_set.py
@@ -13,8 +13,10 @@ def test_supervision_segment_with_full_metadata():
     segment = supervision_set.get('segment-1')
     assert 'segment-1' == segment.id
     assert 'recording-1' == segment.recording_id
+    assert 0 == segment.channel_id
     assert 0.1 == segment.start
     assert 0.3 == segment.duration
+    assert 0.4 == segment.end
     assert 'transcript of the first segment' == segment.text
     assert 'english' == segment.language
     assert 'Norman Dyhrentfurth' == segment.speaker
@@ -25,8 +27,10 @@ def test_supervision_segment_with_no_metadata():
     segment = supervision_set.get('segment-2')
     assert 'segment-2' == segment.id
     assert 'recording-1' == segment.recording_id
+    assert 0 == segment.channel_id  # implicitly filled default value
     assert 0.5 == segment.start
     assert 0.4 == segment.duration
+    assert 0.9 == segment.end
     assert segment.text is None
     assert segment.language is None
     assert segment.speaker is None
@@ -42,17 +46,19 @@ def test_create_supervision_segment_with_all_metadata():
         recording_id='X',
         start=0.0,
         duration=0.1,
+        channel_id=0,
         text='wysokie szczyty',
         language='polish',
-        speaker='Janusz'
+        speaker='Janusz',
+        gender='male'
     )
 
 
 def test_supervision_set_iteration():
     supervision_set = SupervisionSet(
         segments={
-            'X': SupervisionSegment(id='X', recording_id='X', start=2.0, duration=2.5),
-            'Y': SupervisionSegment(id='Y', recording_id='X', start=5.0, duration=5.0),
+            'X': SupervisionSegment(id='X', recording_id='X', channel_id=0, start=2.0, duration=2.5),
+            'Y': SupervisionSegment(id='Y', recording_id='X', channel_id=0, start=5.0, duration=5.0),
         }
     )
     assert 2 == len(supervision_set)
@@ -65,11 +71,13 @@ def test_supervision_set_serialization():
             'segment-1': SupervisionSegment(
                 id='segment-1',
                 recording_id='recording-1',
+                channel_id=0,
                 start=0.1,
                 duration=0.3,
                 text='transcript of the first segment',
                 language='english',
-                speaker='Norman Dyhrentfurth'
+                speaker='Norman Dyhrentfurth',
+                gender='male'
             )
         }
     )


### PR DESCRIPTION
I coded this up to get a better understanding on how the Kaldi data dir maps onto lhotse manifests, and which pieces might be missing on either side. 

The resulting yamls for mini_librispeech look like the following.

AudioSet:
```
- duration_seconds: 10.885
  id: 1272-135031-0000
  num_samples: 174160
  sampling_rate: 16000
  sources:
  - channel_ids:
    - 0
    source: 'flac -c -d -s /Users/pzelasko/jhu/kaldi/egs/mini_librispeech/s5/corpus//LibriSpeech/dev-clean-2/1272//135031/1272-135031-0000.flac '
    type: command
- duration_seconds: 11.13
  id: 1272-135031-0001
  num_samples: 178080
  sampling_rate: 16000
  sources:
  - channel_ids:
    - 0
    source: 'flac -c -d -s /Users/pzelasko/jhu/kaldi/egs/mini_librispeech/s5/corpus//LibriSpeech/dev-clean-2/1272//135031/1272-135031-0001.flac '
    type: command
```

SupervisionSet:
```
- duration: 10.885
  id: 1272-135031-0000
  language: null
  recording_id: 1272-135031-0000
  speaker: 1272-135031
  start: 0.0
  text: BECAUSE YOU WERE SLEEPING INSTEAD OF CONQUERING THE LOVELY ROSE PRINCESS HAS
    BECOME A FIDDLE WITHOUT A BOW WHILE POOR SHAGGY SITS THERE A COOING DOVE
- duration: 11.13
  id: 1272-135031-0001
  language: null
  recording_id: 1272-135031-0001
  speaker: 1272-135031
  start: 0.0
  text: HE HAS GONE AND GONE FOR GOOD ANSWERED POLYCHROME WHO HAD MANAGED TO SQUEEZE
    INTO THE ROOM BESIDE THE DRAGON AND HAD WITNESSED THE OCCURRENCES WITH MUCH INTEREST
```