### PR TITLE
Create CutSet from duration windows of another CutSet

### DIFF
--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -102,7 +102,7 @@ class Cut:
         return self.features.num_features if self.has_features else None
 
     @property
-    def features_type(self) -> Optional[int]:
+    def features_type(self) -> Optional[str]:
         return self.features.type if self.has_features else None
 
     @property
@@ -759,7 +759,7 @@ class CutSet:
             ))
         return CutSet.from_cuts(truncated_cuts)
 
-    def windows(self, duration: Seconds, keep_excessive_supervisions: bool = True) -> 'CutSet':
+    def cut_into_windows(self, duration: Seconds, keep_excessive_supervisions: bool = True) -> 'CutSet':
         """
         Return a new ``CutSet``, made by traversing each ``Cut`` in windows of ``duration`` seconds and
         creating new ``Cut`` out of them.

--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -46,9 +46,9 @@ class Cut:
 
     Note: The SupervisionSegment time boundaries are relative to the beginning of the cut.
     E.g. if the underlying Recording starts at 0s (always true), the Cut starts at 100s,
-    and the SupervisionSegment starts at 3s, it means in the Recording, the supervision actually started at 103s.
-    In some cases, the supervision might have a negative start, or a duration exceeding the duration of the Cut.
-    It means that the supervision in the recording extends beyond the Cut.
+    and the SupervisionSegment starts at 3s, it means that in the Recording the supervision actually started at 103s.
+    In some cases, the supervision might have a negative start, or a duration exceeding the duration of the Cut;
+    this means that the supervision in the recording extends beyond the Cut.
     """
     id: str
 
@@ -75,7 +75,7 @@ class Cut:
 
     @property
     def end(self) -> Seconds:
-        return self.start + self.duration
+        return round(self.start + self.duration, ndigits=3)
 
     @property
     def has_features(self) -> bool:
@@ -610,37 +610,17 @@ class CutSet:
         """
         Create a CutSet from any combination of supervision, feature and recording manifests.
         At least one of ``recording_set`` or ``feature_set`` is required.
-        When ``supervision_set`` is provided, the cuts boundaries will correspond to that of the supervision segments.
-        Otherwise, the boundaries correspond to those found in the ``feature_set``, when available.
-        When only ``recording_set`` is provided, the recordings determine the boundaries.
+        The Cut boundaries correspond to those found in the ``feature_set``, when available,
+        otherwise to those found in the ``recording_set``
+        When a ``supervision_set`` is provided, we'll attach to the Cut all supervisions that
+        have a matching recording ID and are fully contained in the Cut's boundaries.
         """
         assert feature_set is not None or recording_set is not None, \
             "At least one of feature_set and recording_set has to be provided."
         sup_ok, feat_ok, rec_ok = supervision_set is not None, feature_set is not None, recording_set is not None
-        if sup_ok:
-            # Case I: Supervisions are provided.
-            # Use them to determine the cut boundaries and attach recordings and features as available.
-            return CutSet.from_cuts(
-                Cut(
-                    id=str(uuid4()),
-                    start=supervision.start,
-                    duration=supervision.duration,
-                    channel=supervision.channel_id,
-                    recording=recording_set[supervision.recording_id] if rec_ok else None,
-                    features=feature_set.find(
-                        recording_id=supervision.recording_id,
-                        channel_id=supervision.channel_id,
-                        start=supervision.start,
-                        duration=supervision.duration,
-                    ) if feat_ok else None,
-                    # Supervision time boundaries are always relative to the start of the Cut.
-                    supervisions=[supervision.with_offset(-supervision.start)]
-                )
-                for supervision in supervision_set
-            )
         if feat_ok:
-            # Case II: No supervisions, but features are provided.
-            # Use features to determine the cut boundaries and attach recordings as available.
+            # Case I: Features are provided.
+            # Use features to determine the cut boundaries and attach recordings and supervisions as available.
             return CutSet.from_cuts(
                 Cut(
                     id=str(uuid4()),
@@ -648,11 +628,19 @@ class CutSet:
                     duration=features.duration,
                     channel=features.channel_id,
                     features=features,
-                    recording=recording_set[features.recording_id] if rec_ok else None
+                    recording=recording_set[features.recording_id] if rec_ok else None,
+                    # The supervisions' start times are adjusted if the features object starts at time other than 0s.
+                    supervisions=list(supervision_set.find(
+                        recording_id=features.recording_id,
+                        channel=features.channel_id,
+                        start_after=features.start,
+                        end_before=features.end,
+                        adjust_offset=True
+                    )) if sup_ok else []
                 )
                 for features in feature_set
             )
-        # Case II: Only recordings are provided.
+        # Case II: Recordings are provided (and features are not).
         # Use recordings to determine the cut boundaries.
         return CutSet.from_cuts(
             Cut(
@@ -661,6 +649,10 @@ class CutSet:
                 duration=recording.duration_seconds,
                 channel=channel,
                 recording=recording,
+                supervisions=list(supervision_set.find(
+                    recording_id=recording.id,
+                    channel=channel
+                )) if sup_ok else []
             )
             for recording in recording_set
             # A single cut always represents a single channel. When a recording has multiple channels,
@@ -694,6 +686,18 @@ class CutSet:
         :return: a filtered CutSet.
         """
         return CutSet.from_cuts(cut for cut in self if predicate(cut))
+
+    def trim_to_supervisions(self) -> 'CutSet':
+        """
+        Return a new CutSet with Cuts that have identical spans as their supervisions.
+
+        :return: a ``CutSet``.
+        """
+        return CutSet.from_cuts(
+            cut.truncate(offset=segment.start, duration=segment.duration)
+            for cut in self
+            for segment in cut.supervisions
+        )
 
     def pad(
             self,

--- a/lhotse/supervision.py
+++ b/lhotse/supervision.py
@@ -18,11 +18,13 @@ class SupervisionSegment:
 
     @property
     def end(self) -> Seconds:
-        return self.start + self.duration
+        # Precision up to 1ms to avoid float numeric artifacts
+        return round(self.start + self.duration, ndigits=3)
 
     def with_offset(self, offset: Seconds) -> 'SupervisionSegment':
         kwargs = asdict(self)
-        kwargs['start'] += offset
+        # Precision up to 1ms to avoid float numeric artifacts
+        kwargs['start'] = round(kwargs['start'] + offset, ndigits=3)
         return SupervisionSegment(**kwargs)
 
     @staticmethod

--- a/lhotse/supervision.py
+++ b/lhotse/supervision.py
@@ -85,6 +85,9 @@ class SupervisionSet:
             This is useful for creating Cuts. Fom a user perspective, when dealing with a Cut, it is no
             longer helpful to know when the supervisions starts in a recording - instead, it's useful to
             know when the supervision starts relative to the start of the Cut.
+            In the anticipated use-case, ``start_after`` and ``end_before`` would be
+            the beginning and end of a cut;
+            this option converts the times to be relative to the start of the cut.
         :return: An iterator over supervision segments satisfying all criteria.
         """
         return (

--- a/lhotse/supervision.py
+++ b/lhotse/supervision.py
@@ -66,6 +66,34 @@ class SupervisionSet:
         """
         return SupervisionSet.from_segments(seg for seg in self if predicate(seg))
 
+    def find(
+            self,
+            recording_id: str,
+            channel: int,
+            start_after: Seconds = 0,
+            end_before: Optional[Seconds] = None,
+            adjust_offset: bool = False
+    ) -> Iterable[SupervisionSegment]:
+        """
+        Return an iterable of segments that match the provided ``recording_id``.
+
+        :param recording_id: Desired recording ID.
+        :param channel: Return supervisions in the specified channel.
+        :param start_after: When specified, return segments that start after the given value.
+        :param end_before: When specified, return segments that end before the given value.
+        :param adjust_offset: When true, return segments as if the recordings had started at ``start_after``.
+            In other words, :math:`segment.start = segment.start - start_after`.
+        :return: An iterator over supervision segments satisfying all criteria.
+        """
+        return (
+            segment.with_offset(-start_after) if adjust_offset else segment
+            for segment in self
+            if segment.recording_id == recording_id
+               and segment.channel_id == channel
+               and segment.start >= start_after
+               and (end_before is None or segment.end <= end_before)
+        )
+
     def __getitem__(self, item: str) -> SupervisionSegment:
         return self.segments[item]
 

--- a/test/cut/conftest.py
+++ b/test/cut/conftest.py
@@ -32,8 +32,3 @@ def cut2(dummy_features):
 @pytest.fixture
 def cut_set(cut1, cut2):
     return CutSet.from_cuts([cut1, cut2])
-
-
-@pytest.fixture
-def cut_set_with_mixed_cut(cut1, cut2, mixed_cut):
-    return CutSet.from_cuts([cut1, cut2, mixed_cut])

--- a/test/cut/test_cut.py
+++ b/test/cut/test_cut.py
@@ -181,7 +181,10 @@ def test_make_cuts_from_features_recordings(dummy_recording_set, dummy_feature_s
 
 class TestCutOnSupervisions:
     def test_make_cuts_from_recordings_supervisions(self, dummy_recording_set, dummy_supervision_set):
-        cut_set = CutSet.from_manifests(recording_set=dummy_recording_set, supervision_set=dummy_supervision_set)
+        cut_set = CutSet.from_manifests(
+            recording_set=dummy_recording_set,
+            supervision_set=dummy_supervision_set
+        ).trim_to_supervisions()
         cut1 = cut_set[0]
         assert cut1.start == 3.0
         assert cut1.duration == 4.0
@@ -211,7 +214,10 @@ class TestCutOnSupervisions:
         assert cut1.features_type is None
 
     def test_make_cuts_from_features_supervisions(self, dummy_feature_set, dummy_supervision_set):
-        cut_set = CutSet.from_manifests(feature_set=dummy_feature_set, supervision_set=dummy_supervision_set)
+        cut_set = CutSet.from_manifests(
+            feature_set=dummy_feature_set,
+            supervision_set=dummy_supervision_set
+        ).trim_to_supervisions()
         cut1 = cut_set[0]
         assert cut1.start == 3.0
         assert cut1.duration == 4.0
@@ -250,7 +256,7 @@ class TestCutOnSupervisions:
             recording_set=dummy_recording_set,
             feature_set=dummy_feature_set,
             supervision_set=dummy_supervision_set
-        )
+        ).trim_to_supervisions()
         cut1 = cut_set[0]
         assert cut1.start == 3.0
         assert cut1.duration == 4.0
@@ -281,7 +287,6 @@ class TestCutOnSupervisions:
 
 
 class TestNoCutOnSupervisions:
-    @pytest.mark.xfail
     def test_make_cuts_from_recordings_supervisions(self, dummy_recording_set, dummy_supervision_set):
         cut_set = CutSet.from_manifests(recording_set=dummy_recording_set, supervision_set=dummy_supervision_set)
         cut1 = cut_set[0]
@@ -294,7 +299,7 @@ class TestNoCutOnSupervisions:
         assert cut1.supervisions[0].id == 'sup1'
         assert cut1.supervisions[0].recording_id == 'rec1'
         assert cut1.supervisions[0].start == 3.0
-        assert cut1.supervisions[0].start == 7.0
+        assert cut1.supervisions[0].end == 7.0
         assert cut1.supervisions[0].channel_id == 0
         assert cut1.supervisions[0].text == 'dummy text'
 
@@ -311,8 +316,7 @@ class TestNoCutOnSupervisions:
         assert cut1.num_features is None
         assert cut1.features_type is None
 
-    @pytest.mark.xfail
-    def test_make_cuts_from_features_supervisions(self, dummy_recording_set, dummy_supervision_set):
+    def test_make_cuts_from_features_supervisions(self, dummy_feature_set, dummy_supervision_set):
         cut_set = CutSet.from_manifests(feature_set=dummy_feature_set, supervision_set=dummy_supervision_set)
         cut1 = cut_set[0]
         assert cut1.start == 0
@@ -324,15 +328,15 @@ class TestNoCutOnSupervisions:
         assert cut1.supervisions[0].id == 'sup1'
         assert cut1.supervisions[0].recording_id == 'rec1'
         assert cut1.supervisions[0].start == 3.0
-        assert cut1.supervisions[0].start == 7.0
+        assert cut1.supervisions[0].end == 7.0
         assert cut1.supervisions[0].channel_id == 0
         assert cut1.supervisions[0].text == 'dummy text'
 
-        assert cut1.has_recording
-        assert cut1.recording == dummy_recording_set.recordings['rec1']
+        assert not cut1.has_recording
+        assert cut1.recording is None
         assert cut1.sampling_rate == 16000
         assert cut1.recording_id == 'rec1'
-        assert cut1.num_samples == 160000
+        assert cut1.num_samples is None
 
         assert cut1.has_features
         assert cut1.features == dummy_feature_set.features[0]
@@ -341,7 +345,6 @@ class TestNoCutOnSupervisions:
         assert cut1.num_features == 23
         assert cut1.features_type == 'fbank'
 
-    @pytest.mark.xfail
     def test_make_cuts_from_recordings_features_supervisions(
             self,
             dummy_recording_set,
@@ -363,7 +366,7 @@ class TestNoCutOnSupervisions:
         assert cut1.supervisions[0].id == 'sup1'
         assert cut1.supervisions[0].recording_id == 'rec1'
         assert cut1.supervisions[0].start == 3.0
-        assert cut1.supervisions[0].start == 7.0
+        assert cut1.supervisions[0].end == 7.0
         assert cut1.supervisions[0].channel_id == 0
         assert cut1.supervisions[0].text == 'dummy text'
 

--- a/test/cut/test_cut_truncate.py
+++ b/test/cut/test_cut_truncate.py
@@ -213,3 +213,29 @@ def test_truncate_cut_set_offset_random(cut_set):
     # Check that start and end is not the same in every cut
     assert len(set(cut.start for cut in truncated_cut_set)) > 1
     assert len(set(cut.end for cut in truncated_cut_set)) > 1
+
+
+def test_cut_set_windows_even_split_keep_supervisions(cut_set):
+    windows_cut_set = cut_set.windows(duration=5.0)
+    assert len(windows_cut_set) == 4
+    assert all(cut.duration == 5.0 for cut in windows_cut_set)
+
+    cut1, cut2, cut3, cut4 = windows_cut_set
+
+    assert len(cut1.supervisions) == 1
+    assert cut1.supervisions[0].start == 0.5
+    assert cut1.supervisions[0].duration == 6.0
+
+    assert len(cut2.supervisions) == 2
+    assert cut2.supervisions[0].start == -4.5
+    assert cut2.supervisions[0].duration == 6.0
+    assert cut2.supervisions[1].start == 2.0
+    assert cut2.supervisions[1].duration == 2.0
+
+    assert len(cut3.supervisions) == 1
+    assert cut3.supervisions[0].start == 3.0
+    assert cut3.supervisions[0].duration == 2.5
+
+    assert len(cut4.supervisions) == 1
+    assert cut4.supervisions[0].start == -2.0
+    assert cut4.supervisions[0].duration == 2.5

--- a/test/cut/test_cut_truncate.py
+++ b/test/cut/test_cut_truncate.py
@@ -216,7 +216,7 @@ def test_truncate_cut_set_offset_random(cut_set):
 
 
 def test_cut_set_windows_even_split_keep_supervisions(cut_set):
-    windows_cut_set = cut_set.windows(duration=5.0)
+    windows_cut_set = cut_set.cut_into_windows(duration=5.0)
     assert len(windows_cut_set) == 4
     assert all(cut.duration == 5.0 for cut in windows_cut_set)
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -16,6 +16,9 @@ from lhotse.utils import TimeSpan, load_yaml, overlaps, overspans, save_to_yaml
         (TimeSpan(2, 3), TimeSpan(0, 1), False),
         (TimeSpan(1, 1), TimeSpan(0, 1), False),
         (TimeSpan(0, 0), TimeSpan(0, 1), False),
+        (TimeSpan(-1, 1), TimeSpan(0, 1), True),
+        (TimeSpan(0, 1), TimeSpan(-1, 1), True),
+        (TimeSpan(-2, -1), TimeSpan(1, 2), False),
     ]
 )
 def test_overlaps(lhs, rhs, expected):
@@ -40,6 +43,9 @@ def test_overlaps(lhs, rhs, expected):
         (TimeSpan(0, 1), TimeSpan(1, 1), True),
         (TimeSpan(0, 0), TimeSpan(0, 1), False),
         (TimeSpan(0, 1), TimeSpan(0, 0), True),
+        (TimeSpan(-1, 1), TimeSpan(0, 1), True),
+        (TimeSpan(0, 1), TimeSpan(-1, 1), False),
+        (TimeSpan(-2, -1), TimeSpan(1, 2), False),
     ]
 )
 def test_overspans(lhs, rhs, expected):


### PR DESCRIPTION
@danpovey This is what I meant in #64 by "create one large cut from a single feature (matrix) and cut it into windows". Check out the `CutSet.windows()` method. I noticed there were minor bugs while writing that so I added unit tests for all the ways we can create a `CutSet` at this moment.

In `test/cut/test_cut_set.py` you'll see two test classes (groups) - one is called `TestCutOnSupervisions` which is the current behavior if you supply a SupervisionSet during the CutSet creation. It creates cuts to match the supervision segment boundaries and discards the rest. 

I'm considering changing that to the behavior observed in `TestNoCutOnSupervisions` (marked xfail for now because it's not implemented), where we'll create cuts spanning the whole Recording/Features (matrix) duration, and add all observed SupervisionSegments in that time span. It'll make it easier to create windowed CutSets (with the new `.window()` method), and we can add a method called e.g. `CutSet.trim_to_supervisions()` to retain the old behavior.

Does it make sense now?