### PR TITLE
Switchboard data preparation

### DIFF
--- a/docs/corpus.rst
+++ b/docs/corpus.rst
@@ -145,7 +145,8 @@ a CLI tool that create the manifests given a corpus directory.
 
 Currently supported corpora:
 
-- AMI :func:`lhotse.recipes.ami.prepare_ami`
-- Mini LibriMix :func:`lhotse.recipes.librimix.prepare_librimix`
-- Mini LibriSpeech :func:`lhotse.recipes.mini_librispeech.prepare_mini_librispeech`
-- 1997 English Broadcast News :func:`lhotse.recipes.broadcast_news.prepare_broadcast_news`
+- AMI :func:`lhotse.recipes.prepare_ami`
+- English Broadcast News 1997 :func:`lhotse.recipes.prepare_broadcast_news`
+- Mini LibriMix :func:`lhotse.recipes.prepare_librimix`
+- Mini LibriSpeech :func:`lhotse.recipes.prepare_mini_librispeech`
+- Switchboard :func:`lhotse.recipes.prepare_switchboard`

--- a/lhotse/audio.py
+++ b/lhotse/audio.py
@@ -1,4 +1,3 @@
-import os
 import warnings
 from dataclasses import asdict, dataclass
 from io import BytesIO
@@ -7,12 +6,6 @@ from pathlib import Path
 from subprocess import PIPE, run
 from typing import Callable, Dict, Iterable, List, Optional, Union
 
-# Workaround for SoundFile (librosa dep) raising exception when a native library, libsndfile1, is not installed.
-# Read-the-docs does not allow to modify the Docker containers used to build documentation...
-if not os.environ.get('READTHEDOCS', False):
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore')
-        import librosa
 import numpy as np
 
 from lhotse.utils import Decibels, Pathlike, Seconds, SetContainingAnything, load_yaml, save_to_yaml
@@ -48,6 +41,7 @@ class AudioSource:
         Returns numpy array with shapes: (n_samples) for single-channel,
         (n_channels, n_samples) for multi-channel.
         """
+        import librosa
         assert self.type in ('file', 'command')
 
         if self.type == 'command':

--- a/lhotse/bin/modes/recipes/switchboard.py
+++ b/lhotse/bin/modes/recipes/switchboard.py
@@ -27,6 +27,8 @@ def switchboard(
     to what we have.  We also use the Mississippi State transcriptions, which
     we download separately from
     http://www.isip.piconepress.com/projects/switchboard/releases/switchboard_word_alignments.tar.gz
+
+    This data is not available for free - your institution needs to have an LDC subscription.
     """
     prepare_switchboard(
         audio_dir=audio_dir,

--- a/lhotse/bin/modes/recipes/switchboard.py
+++ b/lhotse/bin/modes/recipes/switchboard.py
@@ -1,0 +1,36 @@
+import click
+
+from lhotse.bin.modes import prepare
+from lhotse.recipes import prepare_switchboard
+from lhotse.utils import Pathlike
+
+
+@prepare.command(context_settings=dict(show_default=True))
+@click.argument('audio_dir', type=click.Path(exists=True, file_okay=False))
+@click.argument('transcript_dir', type=click.Path(exists=True, file_okay=False))
+@click.argument('output_dir', type=click.Path())
+@click.option('--omit-silence/--retain-silence', default=True,
+              help='Should the [silence] segments be kept.')
+def switchboard(
+        audio_dir: Pathlike,
+        transcript_dir: Pathlike,
+        output_dir: Pathlike,
+        omit_silence: bool
+):
+    """
+    The Switchboard corpus preparation.
+
+    \b
+    This is conversational telephone speech collected as 2-channel, 8kHz-sampled
+    data.  We are using just the Switchboard-1 Phase 1 training data.
+    The catalog number LDC97S62 (Switchboard-1 Release 2) corresponds, we believe,
+    to what we have.  We also use the Mississippi State transcriptions, which
+    we download separately from
+    http://www.isip.piconepress.com/projects/switchboard/releases/switchboard_word_alignments.tar.gz
+    """
+    prepare_switchboard(
+        audio_dir=audio_dir,
+        transcripts_dir=transcript_dir,
+        output_dir=output_dir,
+        omit_silence=omit_silence
+    )

--- a/lhotse/recipes/__init__.py
+++ b/lhotse/recipes/__init__.py
@@ -1,0 +1,5 @@
+from .ami import prepare_ami
+from .broadcast_news import prepare_broadcast_news
+from .librimix import prepare_librimix
+from .mini_librispeech import prepare_mini_librispeech
+from .switchboard import prepare_switchboard

--- a/lhotse/recipes/broadcast_news.py
+++ b/lhotse/recipes/broadcast_news.py
@@ -13,11 +13,9 @@ from itertools import chain
 from pathlib import Path
 from typing import Dict, Union, Optional, List
 
-from bs4 import BeautifulSoup
 from cytoolz import sliding_window
-from sphfile import SPHFile
 
-from lhotse.audio import AudioSource, Recording, RecordingSet
+from lhotse.audio import Recording, RecordingSet
 from lhotse.supervision import SupervisionSegment, SupervisionSet
 from lhotse.utils import Pathlike, recursion_limit
 
@@ -149,6 +147,7 @@ def try_parse(sgml_path: Path):
     If it runs into Unicode decoding errors, it will try to determine the file's encoding
     and use iconv to automatically convert it to UTF-8.
     """
+    from bs4 import BeautifulSoup
     try:
         return BeautifulSoup(sgml_path.read_text(), 'html.parser')
     except UnicodeDecodeError:

--- a/lhotse/recipes/broadcast_news.py
+++ b/lhotse/recipes/broadcast_news.py
@@ -42,13 +42,12 @@ def prepare_broadcast_news(
     :param output_dir: Directory where the manifests should be written. Can be omitted to avoid writing.
     :return: A dict with manifests. The keys are: ``{'recordings', 'sections', 'segments'}``.
     """
-    audio_dir = Path(audio_dir)
-    transcripts_dir = Path(transcripts_dir)
+    audio_paths = sorted(Path(audio_dir).rglob('*.sph'))
+    sgml_paths = sorted(Path(transcripts_dir).rglob('*.sgml'))
 
-    audio_paths = sorted(audio_dir.rglob('*.sph'))
-    sgml_paths = sorted(transcripts_dir.rglob('*.sgml'))
-
-    recordings = RecordingSet.from_recordings(make_recording(p) for p in audio_paths)
+    recordings = RecordingSet.from_recordings(
+        Recording.from_sphere(p, relative_path_depth=3) for p in audio_paths
+    )
 
     # BeautifulSoup has quite inefficient tag-to-string rendering that uses a recursive implementation;
     # on some systems the recursion limit needs to be raised for this to work.
@@ -73,24 +72,6 @@ def prepare_broadcast_news(
         'sections': section_supervisions,
         'segments': segment_supervisions
     }
-
-
-def make_recording(sph_path: Path) -> Recording:
-    """Read a SPHERE file's header and create the corresponding ``Recording``."""
-    sphf = SPHFile(sph_path)
-    return Recording(
-        id=sph_path.stem,
-        sampling_rate=sphf.format['sample_rate'],
-        num_samples=sphf.format['sample_count'],
-        duration_seconds=sphf.format['sample_count'] / sphf.format['sample_rate'],
-        sources=[
-            AudioSource(
-                type='file',
-                channel_ids=[0],
-                source='/'.join(sph_path.parts[-2:])
-            )
-        ]
-    )
 
 
 def make_supervisions(sgml_path: Pathlike, recording: Recording) -> Dict[str, List[SupervisionSegment]]:

--- a/lhotse/recipes/librimix.py
+++ b/lhotse/recipes/librimix.py
@@ -5,8 +5,6 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Dict, Optional, Union
 
-import pandas as pd
-
 from lhotse.audio import AudioSource, Recording, RecordingSet
 from lhotse.supervision import SupervisionSegment, SupervisionSet
 from lhotse.utils import Pathlike, Seconds
@@ -38,6 +36,7 @@ def prepare_librimix(
         sampling_rate: int = 16000,
         min_segment_seconds: Seconds = 3.0
 ) -> Dict[str, Dict[str, Union[RecordingSet, SupervisionSet]]]:
+    import pandas as pd
     df = pd.read_csv(librimix_csv)
 
     output_dir = Path(output_dir)

--- a/lhotse/recipes/switchboard.py
+++ b/lhotse/recipes/switchboard.py
@@ -1,0 +1,35 @@
+"""
+About the Switchboard corpus
+
+    This is conversational telephone speech collected as 2-channel, 8kHz-sampled
+    data.  We are using just the Switchboard-1 Phase 1 training data.
+    The catalog number LDC97S62 (Switchboard-1 Release 2) corresponds, we believe,
+    to what we have.  We also use the Mississippi State transcriptions, which
+    we download separately from
+    http://www.isip.piconepress.com/projects/switchboard/releases/switchboard_word_alignments.tar.gz
+"""
+import tarfile
+import urllib
+from pathlib import Path
+
+from lhotse.utils import Pathlike
+
+
+SWBD_TEXT_URL = 'http://www.isip.piconepress.com/projects/switchboard/releases/switchboard_word_alignments.tar.gz'
+
+
+def download_and_untar(
+        target_dir: Pathlike = '.',
+        force_download: bool = False,
+        url: str = SWBD_TEXT_URL
+) -> None:
+    target_dir = Path(target_dir)
+    if (target_dir / 'swb_ms98_transcriptions').is_dir():
+        return
+    target_dir.mkdir(parents=True, exist_ok=True)
+    tar_name = 'switchboard_word_alignments.tar.gz'
+    tar_path = target_dir / tar_name
+    if force_download or not tar_path.is_file():
+        urllib.request.urlretrieve(url, filename=tar_path)
+    with tarfile.open(tar_path) as tar:
+        tar.extractall(path=target_dir)

--- a/lhotse/recipes/switchboard.py
+++ b/lhotse/recipes/switchboard.py
@@ -10,22 +10,95 @@ About the Switchboard corpus
 """
 import tarfile
 import urllib
+from itertools import chain
 from pathlib import Path
+from typing import Dict, Union, Optional
 
+from lhotse.audio import RecordingSet, Recording
+from lhotse.supervision import SupervisionSet, SupervisionSegment
 from lhotse.utils import Pathlike
 
 
 SWBD_TEXT_URL = 'http://www.isip.piconepress.com/projects/switchboard/releases/switchboard_word_alignments.tar.gz'
 
 
+def prepare_switchboard(
+        audio_dir: Pathlike,
+        transcripts_dir: Optional[Pathlike] = None,
+        output_dir: Optional[Pathlike] = None,
+        omit_silence: bool = True
+) -> Dict[str, Union[RecordingSet, SupervisionSet]]:
+    """
+    Prepare manifests for the Switchboard corpus.
+    We create two manifests: one with recordings, and the other one with text supervisions.
+
+    :param audio_dir: Path to ``LDC97S62`` package.
+    :param transcripts_dir: Path to the transcripts directory (typically named "swb_ms98_transcriptions").
+    :param output_dir: Directory where the manifests should be written. Can be omitted to avoid writing.
+    :return: A dict with manifests. The keys are: ``{'recordings', 'supervisions'}``.
+    """
+    if transcripts_dir is None:
+        transcripts_dir = download_and_untar()
+    audio_paths = sorted(Path(audio_dir).rglob('*.sph'))
+    text_paths = sorted(Path(transcripts_dir).rglob('*trans.text'))
+
+    groups = []
+    name_to_text = {p.stem.split('-')[0]: p for p in text_paths}
+    for ap in audio_paths:
+        name = ap.stem.replace('sw0', 'sw')
+        groups.append({'audio': ap, 'text-0': name_to_text[f'{name}A'], 'text-1': name_to_text[f'{name}B']})
+
+    recordings = RecordingSet.from_recordings(
+        Recording.from_sphere(group['audio'], relative_path_depth=3) for group in groups
+    )
+    supervisions = SupervisionSet.from_segments(chain.from_iterable(
+        make_segments(
+            transcript_path=group[f'text-{channel}'],
+            recording=recording,
+            channel=channel,
+            omit_silence=omit_silence
+        )
+        for group, recording in zip(groups, recordings)
+        for channel in [0, 1]
+    ))
+    if output_dir is not None:
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        recordings.to_yaml(output_dir / 'recordings.yml')
+        supervisions.to_yaml(output_dir / 'supervisions.yml')
+    return {
+        'recordings': recordings,
+        'supervisions': supervisions
+    }
+
+
+def make_segments(transcript_path: Path, recording: Recording, channel: int, omit_silence: bool = True):
+    lines = transcript_path.read_text().splitlines()
+    return [
+        SupervisionSegment(
+            id=segment_id,
+            recording_id=recording.id,
+            start=float(start),
+            duration=round(float(end) - float(start), ndigits=3),
+            channel_id=channel,
+            text=' '.join(words),
+            language='English',
+            speaker=f'{recording.id}A'
+        )
+        for segment_id, start, end, *words in map(str.split, lines)
+        if words[0] != '[silence]' or not omit_silence
+    ]
+
+
 def download_and_untar(
         target_dir: Pathlike = '.',
         force_download: bool = False,
         url: str = SWBD_TEXT_URL
-) -> None:
+) -> Path:
     target_dir = Path(target_dir)
-    if (target_dir / 'swb_ms98_transcriptions').is_dir():
-        return
+    transcript_dir = target_dir / 'swb_ms98_transcriptions'
+    if transcript_dir.is_dir():
+        return transcript_dir
     target_dir.mkdir(parents=True, exist_ok=True)
     tar_name = 'switchboard_word_alignments.tar.gz'
     tar_path = target_dir / tar_name
@@ -33,3 +106,4 @@ def download_and_untar(
         urllib.request.urlretrieve(url, filename=tar_path)
     with tarfile.open(tar_path) as tar:
         tar.extractall(path=target_dir)
+    return transcript_dir

--- a/lhotse/recipes/switchboard.py
+++ b/lhotse/recipes/switchboard.py
@@ -7,6 +7,8 @@ About the Switchboard corpus
     to what we have.  We also use the Mississippi State transcriptions, which
     we download separately from
     http://www.isip.piconepress.com/projects/switchboard/releases/switchboard_word_alignments.tar.gz
+
+    This data is not available for free - your institution needs to have an LDC subscription.
 """
 import tarfile
 import urllib

--- a/lhotse/recipes/switchboard.py
+++ b/lhotse/recipes/switchboard.py
@@ -35,6 +35,7 @@ def prepare_switchboard(
     :param audio_dir: Path to ``LDC97S62`` package.
     :param transcripts_dir: Path to the transcripts directory (typically named "swb_ms98_transcriptions").
     :param output_dir: Directory where the manifests should be written. Can be omitted to avoid writing.
+    :param omit_silence: Whether supervision segments with ``[silence]`` token should be removed or kept.
     :return: A dict with manifests. The keys are: ``{'recordings', 'supervisions'}``.
     """
     if transcripts_dir is None:

--- a/test/cut/test_cut_truncate.py
+++ b/test/cut/test_cut_truncate.py
@@ -83,6 +83,11 @@ def test_truncate_cut(
     assert isclose(truncated_cut.end, expected_end)
 
 
+def test_truncate_above_duration_has_no_effect(overlapping_supervisions_cut):
+    truncated_cut = overlapping_supervisions_cut.truncate(duration=1.0, preserve_id=True)
+    assert truncated_cut == overlapping_supervisions_cut
+
+
 @pytest.fixture
 def simple_mixed_cut():
     return MixedCut(

--- a/test/test_recording_set.py
+++ b/test/test_recording_set.py
@@ -150,3 +150,30 @@ def test_add_recording_sets():
     recording_set_2 = DummyManifest(RecordingSet, begin_id=5, end_id=10)
     combined = recording_set_1 + recording_set_2
     assert combined == expected
+
+
+@pytest.mark.parametrize(
+    ['relative_path_depth', 'expected_source_path'],
+    [
+        (None, 'test/fixtures/stereo.sph'),
+        (1, 'stereo.sph'),
+        (2, 'fixtures/stereo.sph'),
+        (3, 'test/fixtures/stereo.sph'),
+        (4, 'test/fixtures/stereo.sph')
+    ]
+)
+def test_recording_from_sphere(relative_path_depth, expected_source_path):
+    rec = Recording.from_sphere('test/fixtures/stereo.sph', relative_path_depth=relative_path_depth)
+    assert rec == Recording(
+        id='stereo',
+        sampling_rate=8000,
+        num_samples=8000,
+        duration_seconds=1.0,
+        sources=[
+            AudioSource(
+                type='file',
+                channel_ids=[0, 1],
+                source=expected_source_path
+            )
+        ]
+    )


### PR DESCRIPTION
This introduces a data preparation recipe for Switchboard. 

It also fixes an issue I observed after merging AMI recipe - the code was not ready to handle `None` returned from `cut.truncate()`, I played around with the API and figured it's better to return an unmodified Cut when the user requires a longer duration than available, rather than returning `None`.

Notably, there is no special text preprocessing, probably I should add it to avoid partial words (`ex[ample]-`) in SWBD transcripts (I might just mimic Kaldi data prep behavior - @danpovey any comments?).

I will also try to add dialog act and sentiment labels here (not sure yet whether as a part of this PR or a separate one)