### PR TITLE
Switchboard sentiment annotations

### DIFF
--- a/lhotse/bin/modes/recipes/__init__.py
+++ b/lhotse/bin/modes/recipes/__init__.py
@@ -1,3 +1,4 @@
 from .broadcast_news import *
 from .librimix import *
 from .mini_librispeech import *
+from .switchboard import *

--- a/lhotse/bin/modes/recipes/switchboard.py
+++ b/lhotse/bin/modes/recipes/switchboard.py
@@ -9,12 +9,15 @@ from lhotse.utils import Pathlike
 @click.argument('audio_dir', type=click.Path(exists=True, file_okay=False))
 @click.argument('transcript_dir', type=click.Path(exists=True, file_okay=False))
 @click.argument('output_dir', type=click.Path())
+@click.option('sentiment_dir', type=click.Path(exists=True, file_okay=False),
+              help='Optional path to LDC2020T14 package with sentiment annotations for SWBD.')
 @click.option('--omit-silence/--retain-silence', default=True,
               help='Should the [silence] segments be kept.')
 def switchboard(
         audio_dir: Pathlike,
         transcript_dir: Pathlike,
         output_dir: Pathlike,
+        sentiment_dir: Pathlike,
         omit_silence: bool
 ):
     """
@@ -33,6 +36,7 @@ def switchboard(
     prepare_switchboard(
         audio_dir=audio_dir,
         transcripts_dir=transcript_dir,
+        sentiment_dir=sentiment_dir,
         output_dir=output_dir,
         omit_silence=omit_silence
     )

--- a/lhotse/bin/modes/recipes/switchboard.py
+++ b/lhotse/bin/modes/recipes/switchboard.py
@@ -7,16 +7,16 @@ from lhotse.utils import Pathlike
 
 @prepare.command(context_settings=dict(show_default=True))
 @click.argument('audio-dir', type=click.Path(exists=True, file_okay=False))
-@click.argument('transcript-dir', type=click.Path(exists=True, file_okay=False))
 @click.argument('output-dir', type=click.Path())
+@click.option('--transcript-dir', type=click.Path(exists=True, file_okay=False))
 @click.option('--sentiment-dir', type=click.Path(exists=True, file_okay=False),
               help='Optional path to LDC2020T14 package with sentiment annotations for SWBD.')
 @click.option('--omit-silence/--retain-silence', default=True,
               help='Should the [silence] segments be kept.')
 def switchboard(
         audio_dir: Pathlike,
-        transcript_dir: Pathlike,
         output_dir: Pathlike,
+        transcript_dir: Pathlike,
         sentiment_dir: Pathlike,
         omit_silence: bool
 ):

--- a/lhotse/bin/modes/recipes/switchboard.py
+++ b/lhotse/bin/modes/recipes/switchboard.py
@@ -6,10 +6,10 @@ from lhotse.utils import Pathlike
 
 
 @prepare.command(context_settings=dict(show_default=True))
-@click.argument('audio_dir', type=click.Path(exists=True, file_okay=False))
-@click.argument('transcript_dir', type=click.Path(exists=True, file_okay=False))
-@click.argument('output_dir', type=click.Path())
-@click.option('sentiment_dir', type=click.Path(exists=True, file_okay=False),
+@click.argument('audio-dir', type=click.Path(exists=True, file_okay=False))
+@click.argument('transcript-dir', type=click.Path(exists=True, file_okay=False))
+@click.argument('output-dir', type=click.Path())
+@click.option('--sentiment-dir', type=click.Path(exists=True, file_okay=False),
               help='Optional path to LDC2020T14 package with sentiment annotations for SWBD.')
 @click.option('--omit-silence/--retain-silence', default=True,
               help='Should the [silence] segments be kept.')


### PR DESCRIPTION
I've added an option to provide the path to LDC2020T14 during SWBD data preparation - then, it adds the sentiment labels to the supervisions. I also fixed some small issues with the CLI.

With sentiment labels the supervisions look like this (there are multiple annotators and the dataset creators do not disambiguate the labels, leaving it up to the user - so did I):

```yaml
- channel_id: 0
  custom:
    sentiment0: Neutral-{Mixed emotion}
    sentiment1: Neutral-{Mixed  emotion}
    sentiment2: Positive-{Industrialize}
  duration: 9.474
  id: sw2005A-ms98-a-0051
  language: English
  recording_id: sw02005
  speaker: sw02005A
  start: 381.31075
  text: um i[n]- matter of fact in the United States we used to have extended families
    it wasn't but i guess as we become more industrialized and more you know less
    in a rural situation
- channel_id: 0
  custom:
    sentiment0: Positive-{Easier}
    sentiment1: Positive-{Easier}
    sentiment2: Positive-{Easier}
  duration: 10.446
  id: sw2005A-ms98-a-0052
  language: English
  recording_id: sw02005
  speaker: sw02005A
  start: 390.784625
  text: we we don't we we we choose not to deal with the extended family because we
    feel it's kind of cumbersome when in reality it makes things much much easier
```