### PR TITLE
Extracting areas with no supervisions as cuts

### DIFF
--- a/lhotse/recipes/ami.py
+++ b/lhotse/recipes/ami.py
@@ -145,7 +145,7 @@ def parse_ami_annotations(gzip_file: Pathlike) -> Dict[str, List[AmiSegmentAnnot
 
 def prepare_ami(
         data_dir: Pathlike,
-        output_dir: Pathlike
+        output_dir: Optional[Pathlike] = None,
 ) -> Dict[str, Dict[str, Union[RecordingSet, SupervisionSet]]]:
     """
     Returns the manifests which consist of the Recordings and Supervisions
@@ -155,8 +155,9 @@ def prepare_ami(
     :return: a Dict whose key is ('train', 'dev', 'eval'), and the value is Dicts with keys 'audio' and 'supervisions'.
     """
     data_dir = Path(data_dir)
-    output_dir = Path(output_dir)
-    output_dir.mkdir(parents=True, exist_ok=True)
+    if output_dir is not None:
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
 
     anotation_lists = parse_ami_annotations(data_dir / 'annotations.gzip')
     wav_dir = data_dir / 'wav_db'
@@ -192,7 +193,6 @@ def prepare_ami(
         if len(recordings) == 0:
             continue
         audio = RecordingSet.from_recordings(recordings)
-        audio.to_json(output_dir / f'audio_{part}.json')
 
         # Supervisions
         segments_by_pause = []
@@ -213,7 +213,9 @@ def prepare_ami(
                             text=subseg_info.text
                         ))
         supervision = SupervisionSet.from_segments(segments_by_pause)
-        supervision.to_json(output_dir / f'supervisions_{part}.json')
+        if output_dir is not None:
+            audio.to_json(output_dir / f'audio_{part}.json')
+            supervision.to_json(output_dir / f'supervisions_{part}.json')
 
         manifests[part] = {
             'audio': audio,

--- a/lhotse/recipes/librimix.py
+++ b/lhotse/recipes/librimix.py
@@ -31,7 +31,7 @@ def download_and_unzip(
 
 def prepare_librimix(
         librimix_csv: Pathlike,
-        output_dir: Pathlike,
+        output_dir: Optional[Pathlike] = None,
         with_precomputed_mixtures: bool = False,
         sampling_rate: int = 16000,
         min_segment_seconds: Seconds = 3.0
@@ -39,8 +39,9 @@ def prepare_librimix(
     import pandas as pd
     df = pd.read_csv(librimix_csv)
 
-    output_dir = Path(output_dir)
-    output_dir.mkdir(parents=True, exist_ok=True)
+    if output_dir is not None:
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
 
     manifests = defaultdict(dict)
 
@@ -68,9 +69,10 @@ def prepare_librimix(
         for idx, row in df.iterrows()
         if row['length'] / sampling_rate > min_segment_seconds
     )
-    audio_sources.to_json(output_dir / 'audio_sources.json')
     supervision_sources = make_corresponding_supervisions(audio_sources)
-    supervision_sources.to_json(output_dir / 'supervisions_sources.json')
+    if output_dir is not None:
+        audio_sources.to_json(output_dir / 'audio_sources.json')
+        supervision_sources.to_json(output_dir / 'supervisions_sources.json')
 
     manifests['sources'] = {
         'audio': audio_sources,
@@ -98,9 +100,10 @@ def prepare_librimix(
             for idx, row in df.iterrows()
             if row['length'] / sampling_rate > min_segment_seconds
         )
-        audio_mix.to_json(output_dir / 'audio_mix.json')
         supervision_mix = make_corresponding_supervisions(audio_mix)
-        supervision_mix.to_json(output_dir / 'supervisions_mix.json')
+        if output_dir is not None:
+            audio_mix.to_json(output_dir / 'audio_mix.json')
+            supervision_mix.to_json(output_dir / 'supervisions_mix.json')
         manifests['premixed'] = {
             'audio': audio_mix,
             'supervisions': supervision_mix
@@ -126,9 +129,10 @@ def prepare_librimix(
             for idx, row in df.iterrows()
             if row['length'] / sampling_rate > min_segment_seconds
         )
-        audio_noise.to_json(output_dir / 'audio_noise.json')
         supervision_noise = make_corresponding_supervisions(audio_noise)
-        supervision_noise.to_json(output_dir / 'supervisions_noise.json')
+        if output_dir is not None:
+            audio_noise.to_json(output_dir / 'audio_noise.json')
+            supervision_noise.to_json(output_dir / 'supervisions_noise.json')
         manifests['noise'] = {
             'audio': audio_noise,
             'supervisions': supervision_noise

--- a/test/cut/test_cut_set.py
+++ b/test/cut/test_cut_set.py
@@ -2,6 +2,7 @@ from tempfile import NamedTemporaryFile
 
 import pytest
 
+from lhotse import SupervisionSegment
 from lhotse.cut import Cut, CutSet, MixedCut, MixTrack
 
 
@@ -73,3 +74,34 @@ def test_filter_cut_set(cut_set, cut1):
     filtered = cut_set.filter(lambda cut: cut.id == 'cut-1')
     assert len(filtered) == 1
     assert list(filtered)[0] == cut1
+
+
+def test_trim_to_unsupervised_segments():
+    cut_set = CutSet.from_cuts([
+        # Yields 3 unsupervised cuts - before first supervision,
+        # between sup2 and sup3, and after sup3.
+        Cut('cut1', start=0, duration=30, channel=0, supervisions=[
+            SupervisionSegment('sup1', 'rec1', start=1.5, duration=8.5),
+            SupervisionSegment('sup2', 'rec1', start=10, duration=5),
+            SupervisionSegment('sup3', 'rec1', start=20, duration=8),
+        ]),
+        # Does not yield any "unsupervised" cut.
+        Cut('cut2', start=0, duration=30, channel=0, supervisions=[
+            SupervisionSegment('sup4', 'rec1', start=0, duration=30),
+        ]),
+    ])
+    unsupervised_cuts = cut_set.trim_to_unsupervised_segments()
+
+    assert len(unsupervised_cuts) == 3
+
+    assert unsupervised_cuts[0].start == 0
+    assert unsupervised_cuts[0].duration == 1.5
+    assert unsupervised_cuts[0].supervisions == []
+
+    assert unsupervised_cuts[1].start == 15
+    assert unsupervised_cuts[1].duration == 5
+    assert unsupervised_cuts[1].supervisions == []
+
+    assert unsupervised_cuts[2].start == 28
+    assert unsupervised_cuts[2].duration == 2
+    assert unsupervised_cuts[2].supervisions == []


### PR DESCRIPTION
Sometimes it's helpful to extract non-speech segments from a recording and use them as additive "in-domain" noise - this is now supported by `CutSet`. 

I've also improved the plotting so that it highlights the supervision areas in green, and added a multi-row plot for mixed cuts which is useful for debugging/understanding data (I wish I had come up with that earlier).
<img width="397" alt="image" src="https://user-images.githubusercontent.com/15930688/92556857-ef979300-f238-11ea-81ee-f31efe988ef9.png">


Finally, all corpus data preparation functions have an optional `output_dir` now, if storing the manifests on disk is not required.