### PR TITLE
Grouping AMI channels together + multi-channel cut API improvements

### DIFF
--- a/lhotse/__init__.py
+++ b/lhotse/__init__.py
@@ -1,4 +1,4 @@
-from .audio import RecordingSet, Recording
+from .audio import RecordingSet, Recording, AudioSource
 from .augmentation import WavAugmenter
 from .cut import CutSet, Cut
 from .features import *

--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -658,10 +658,20 @@ class MixedCut(CutUtilsMixin):
             use_log_energy=self.features_type in ('fbank', 'mfcc')
         ))
 
-    def load_features(self) -> Optional[np.ndarray]:
-        """Loads the features of the source cuts and mixes them on-the-fly."""
+    def load_features(self, mixed: bool = True) -> Optional[np.ndarray]:
+        """
+        Loads the features of the source cuts and mixes them on-the-fly.
+
+        :param mixed: when True (default), returns a 2D array of features mixed in the feature domain.
+            Otherwise returns a 3D array with the first dimension equal to the number of tracks.
+        :return: A numpy ndarray with features and with shape ``(num_frames, num_features)``,
+            or ``(num_tracks, num_frames, num_features)``
+        """
         if not self.has_features:
             return None
+        if not mixed:
+            # TODO: add zero padding + offsets
+            return np.stack([track.cut.load_features() for track in self.tracks])
         first_cut = self.tracks[0].cut
         mixer = FeatureMixer(
             feature_extractor=create_default_feature_extractor(self._first_non_padding_cut.features.type),
@@ -676,21 +686,25 @@ class MixedCut(CutUtilsMixin):
             )
         return mixer.mixed_feats
 
-    def load_audio(self) -> Optional[np.ndarray]:
+    def load_audio(self, mixed: bool = True) -> Optional[np.ndarray]:
         """
         Loads the audios of the source cuts and mix them on-the-fly.
 
-        :return: the mixed audio samples in an ndarray, with the shape (1, sample_num)
+        :param mixed: When True (default), returns a mono mix of the underlying tracks.
+            Otherwise returns a numpy array with the number of channels equal to the number of tracks.
+        :return: A numpy ndarray with audio samples and with shape ``(num_channels, num_samples)``
         """
         if not self.has_recording:
             return None
-        mixer = AudioMixer(self.tracks[0].cut.load_audio())
+        if not mixed:
+            # TODO: add zero padding + offsets
+            return np.vstack([track.cut.load_audio() for track in self.tracks])
+        mixer = AudioMixer(self.tracks[0].cut.load_audio(), sampling_rate=self.tracks[0].cut.sampling_rate)
         for track in self.tracks[1:]:
             mixer.add_to_mix(
                 audio=track.cut.load_audio(),
                 snr=track.snr,
                 offset=track.offset,
-                sampling_rate=track.cut.sampling_rate
             )
         return mixer.mixed_audio
 
@@ -974,11 +988,11 @@ class CutSet(JsonMixin, YamlMixin):
     def mix_same_recording_channels(self) -> 'CutSet':
         """
         Find cuts that come from the same recording and have matching start and end times, but
-        represent different channels. Then, mix them together (in matching groupbs) and return
+        represent different channels. Then, mix them together (in matching groups) and return
         a new ``CutSet`` that contains their mixes. This is useful for processing microphone array
         recordings.
 
-        It is inteded to be used as the first operation after creating a new ``CutSet`` (but
+        It is intended to be used as the first operation after creating a new ``CutSet`` (but
         might also work in other circumstances, e.g. if it was cut to windows first).
 
         Example:
@@ -986,7 +1000,7 @@ class CutSet(JsonMixin, YamlMixin):
             >>> cut_set = CutSet.from_manifests(recordings=ami['train']['recordings'])
             >>> multi_channel_cut_set = cut_set.mix_same_recording_channels()
 
-        In AMI example the ``multi_channel_cut_set`` will yield MixedCuts that hold all single-channel
+        In the AMI example, the ``multi_channel_cut_set`` will yield MixedCuts that hold all single-channel
         Cuts together.
         """
         if self.mixed_cuts:

--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -700,17 +700,27 @@ class MixedCut(CutUtilsMixin):
             )
         return mixer.mixed_audio if mixed else mixer.unmixed_audio
 
+    def plot_tracks_features(self):
+        """
+        Display the feature matrix as an image. Requires matplotlib to be installed.
+        """
+        import matplotlib.pyplot as plt
+        fig, axes = plt.subplots(len(self.tracks))
+        features = self.load_features(mixed=False)
+        fmin, fmax = features.min(), features.max()
+        for idx, ax in enumerate(axes):
+            ax.imshow(np.flip(features[idx].transpose(1, 0), 0), vmin=fmin, vmax=fmax)
+        return axes
+
     def plot_tracks_audio(self):
         """
         Display plots of the individual tracks' waveforms. Requires matplotlib to be installed.
         """
         import matplotlib.pyplot as plt
-        fig, axes = plt.subplots(len(self.tracks), sharex=True)
-        for track, ax in zip(self.tracks, axes):
-            samples = np.hstack([
-                np.zeros(round(self.sampling_rate * track.offset)),
-                track.cut.load_audio().squeeze()
-            ])
+        audio = self.load_audio(mixed=False)
+        fig, axes = plt.subplots(len(self.tracks), sharex=True, sharey=True)
+        for idx, (track, ax) in enumerate(zip(self.tracks, axes)):
+            samples = audio[idx, :]
             ax.plot(np.linspace(0, track.offset + track.cut.duration, len(samples)), samples)
             for supervision in track.cut.supervisions:
                 supervision = supervision.trim(track.cut.duration)

--- a/lhotse/features/mixer.py
+++ b/lhotse/features/mixer.py
@@ -19,29 +19,54 @@ class FeatureMixer:
             feature_extractor: FeatureExtractor,
             base_feats: np.ndarray,
             frame_shift: Seconds,
-            log_energy_floor: float = -1000.0
+            padding_value: float = -1000.0
     ):
         """
-        :param feature_extractor: The ``FeatureExtractor`` that specifies how to mix the features.
+        :param feature_extractor: The ``FeatureExtractor`` instance that specifies how to mix the features.
         :param base_feats: The features used to initialize the ``FeatureMixer`` are a point of reference
             in terms of energy and offset for all features mixed into them.
         :param frame_shift: Required to correctly compute offset and padding during the mix.
-        :param log_energy_floor: The value used to pad the shorter features during the mix.
+        :param padding_value: The value used to pad the shorter features during the mix.
+            This value is adequate only for log space features. For non-log space features,
+            e.g. energies, use either 0 or a small positive value like 1e-5.
         """
         self.feature_extractor = feature_extractor
-        # The mixing output will be available in self.mixed_feats
-        self.mixed_feats = base_feats
+        self.tracks = [base_feats]
+        self.gains = []
         # Keep a pre-computed energy value of the features that we initialize the Mixer with;
         # it is required to compute gain ratios that satisfy SNR during the mix.
         self.frame_shift = frame_shift
         self.reference_energy = feature_extractor.compute_energy(base_feats)
         assert self.reference_energy > 0.0, \
             f"To perform mix, energy must be non-zero and non-negative (got {self.reference_energy})"
-        self.log_energy_floor = log_energy_floor
+        self.padding_value = padding_value
 
     @property
     def num_features(self):
-        return self.mixed_feats.shape[1]
+        return self.tracks[0].shape[1]
+
+    @property
+    def unmixed_feats(self) -> np.ndarray:
+        """
+        Return a numpy ndarray with the shape (num_tracks, num_frames, num_features), where each track's
+        feature matrix is padded and scaled adequately to the offsets and SNR used in ``add_to_mix`` call.
+        """
+        return np.stack(self.tracks)
+
+    @property
+    def mixed_feats(self) -> np.ndarray:
+        """
+        Return a numpy ndarray with the shape (num_frames, num_features) - a mono mixed feature matrix
+        of the tracks supplied with ``add_to_mix`` calls.
+        """
+        result = self.tracks[0]
+        for feats_to_add, gain in zip(self.tracks[1:], self.gains):
+            result = self.feature_extractor.mix(
+                features_a=result,
+                features_b=feats_to_add,
+                energy_scaling_factor_b=gain
+            )
+        return result
 
     def add_to_mix(
             self,
@@ -51,35 +76,36 @@ class FeatureMixer:
     ):
         """
         Add feature matrix of a new track into the mix.
-        :param feats: A 2-d feature matrix to be mixed in.
-        :param snr: Signal-to-noise ratio, assuming `feats` represents noise (positive SNR - lower `feats` energy,
-        negative SNR - higher `feats` energy)
-        :param offset: How many seconds to shift `feats` in time. For mixing, the signal will be padded before
+        :param feats: A 2D feature matrix to be mixed in.
+        :param snr: Signal-to-noise ratio, assuming ``feats`` represents noise (positive SNR - lower ``feats`` energy,
+        negative SNR - higher ``feats`` energy)
+        :param offset: How many seconds to shift ``feats`` in time. For mixing, the signal will be padded before
         the start with low energy values.
-        :return:
         """
         assert offset >= 0.0, "Negative offset in mixing is not supported."
 
+        reference_feats = self.tracks[0]
         num_frames_offset = round(offset / self.frame_shift)
-        current_num_frames = self.mixed_feats.shape[0]
+        current_num_frames = reference_feats.shape[0]
         incoming_num_frames = feats.shape[0] + num_frames_offset
         mix_num_frames = max(current_num_frames, incoming_num_frames)
 
-        existing_feats = self.mixed_feats
         feats_to_add = feats
 
         # When the existing frames are less than what we anticipate after the mix,
         # we need to pad after the end of the existing features mixed so far.
         if current_num_frames < mix_num_frames:
-            existing_feats = np.vstack([
-                self.mixed_feats,
-                self.log_energy_floor * np.ones((mix_num_frames - current_num_frames, self.num_features))
-            ])
+            for idx in range(len(self.tracks)):
+                padded_track = np.vstack([
+                    self.tracks[idx],
+                    self.padding_value * np.ones((mix_num_frames - current_num_frames, self.num_features))
+                ])
+                self.tracks[idx] = padded_track
 
         # When there is an offset, we need to pad before the start of the features we're adding.
         if offset > 0:
             feats_to_add = np.vstack([
-                self.log_energy_floor * np.ones((num_frames_offset, self.num_features)),
+                self.padding_value * np.ones((num_frames_offset, self.num_features)),
                 feats_to_add
             ])
 
@@ -90,7 +116,7 @@ class FeatureMixer:
         if incoming_num_frames < mix_num_frames:
             feats_to_add = np.vstack([
                 feats_to_add,
-                self.log_energy_floor * np.ones((mix_num_frames - incoming_num_frames, self.num_features))
+                self.padding_value * np.ones((mix_num_frames - incoming_num_frames, self.num_features))
             ])
 
         # When SNR is requested, find what gain is needed to satisfy the SNR
@@ -103,8 +129,5 @@ class FeatureMixer:
             target_energy = self.reference_energy * (10.0 ** (-snr / 10))
             gain = target_energy / added_feats_energy
 
-        self.mixed_feats = self.feature_extractor.mix(
-            features_a=existing_feats,
-            features_b=feats_to_add,
-            energy_scaling_factor_b=gain
-        )
+        self.tracks.append(feats_to_add)
+        self.gains.append(gain)

--- a/lhotse/features/spectrogram.py
+++ b/lhotse/features/spectrogram.py
@@ -34,7 +34,7 @@ class Spectrogram(TorchaudioFeatureExtractor):
     def feature_dim(self, sampling_rate: int) -> int:
         from torchaudio.compliance.kaldi import _next_power_of_2
         window_size = int(self.config.frame_length * sampling_rate)
-        return _next_power_of_2(window_size) if self.config.round_to_power_of_two else window_size
+        return _next_power_of_2(window_size) // 2 + 1 if self.config.round_to_power_of_two else window_size
 
     @staticmethod
     def mix(features_a: np.ndarray, features_b: np.ndarray, energy_scaling_factor_b: float) -> np.ndarray:

--- a/lhotse/recipes/ami.py
+++ b/lhotse/recipes/ami.py
@@ -95,6 +95,8 @@ def download(
 
 class AmiSegmentAnnotation(NamedTuple):
     text: str
+    speaker: str
+    gender: str
     begin_time: Seconds
     end_time: Seconds
 
@@ -106,7 +108,7 @@ def parse_ami_annotations(gzip_file: Pathlike) -> Dict[str, List[AmiSegmentAnnot
             line = re.sub(r'\s+$', '', line.decode())
             if re.match(r'^Found', line) or re.match(r'^[Oo]bs', line):
                 continue
-            meet_id, _, _, channel, _, _, aut_btime, aut_etime, trans, puncts_times = line.split('\t')
+            meet_id, _, speaker, channel, _, _, aut_btime, aut_etime, trans, puncts_times = line.split('\t')
 
             # Split transcript by punctuations
             trans = re.split(r' *[.,?!:] *', re.sub(r'[.,?!:\s]+$', '', trans.upper()))
@@ -125,7 +127,7 @@ def parse_ami_annotations(gzip_file: Pathlike) -> Dict[str, List[AmiSegmentAnnot
                     puncts_times.append(aut_etime)
                 if len(puncts_times) == seg_num + 1:
                     puncts_times.pop()
-                    assert(puncts_times[-1] <= aut_etime)
+                    assert (puncts_times[-1] <= aut_etime)
                 assert len(puncts_times) == seg_num and aut_btime <= puncts_times[0]
             except (ValueError, AssertionError):
                 continue
@@ -133,7 +135,13 @@ def parse_ami_annotations(gzip_file: Pathlike) -> Dict[str, List[AmiSegmentAnnot
             # Make the begin/end points list
             seg_btimes = [aut_btime] + puncts_times
             seg_btimes.pop()
-            seg_times = [AmiSegmentAnnotation(t, b, e) for t, b, e in zip(trans, seg_btimes, puncts_times)]
+            seg_times = [AmiSegmentAnnotation(
+                text=t,
+                speaker=speaker,
+                gender=speaker[0],
+                begin_time=b,
+                end_time=e
+            ) for t, b, e in zip(trans, seg_btimes, puncts_times)]
 
             wav_name = f'{meet_id}.Headset-{int(channel)}.wav'
             if wav_name not in anotations:
@@ -161,58 +169,70 @@ def prepare_ami(
         output_dir.mkdir(parents=True, exist_ok=True)
 
     anotation_lists = parse_ami_annotations(data_dir / 'annotations.gzip')
+    # Create a mapping from a tuple of (session_id, channel) to the list of annotations.
+    # This way we can map the supervisions to the right channels in a multi-channel recording.
+    annotation_by_id_and_channel = {
+        (filename.split('.')[0], int(filename[-5])): annotations
+        for filename, annotations in anotation_lists.items()
+    }
     wav_dir = data_dir / 'wav_db'
-    audio_paths = list(wav_dir.rglob('*.wav'))
+    audio_paths = wav_dir.rglob('*.wav')
+    # Group together multiple channels from the same session.
+    # We will use that to create a Recording with multiple sources (channels).
+    from cytoolz import groupby
+    channel_wavs = groupby(lambda p: p.parts[-3], audio_paths)
 
     manifests = defaultdict(dict)
 
     for part in dataset_parts:
         # Audio
         recordings = []
-        for audio_path in audio_paths:
-            audio_idx = audio_path.name
-            if re.sub(r'\..*', '', audio_idx) not in dataset_parts[part]:
+        for session_name, channel_paths in channel_wavs.items():
+            if session_name not in dataset_parts[part]:
                 continue
-            if audio_idx not in anotation_lists:
-                logging.warning(f'No annotation found for {audio_idx}')
-                continue
-            audio_info = torchaudio.info(str(audio_path))[0]
-
+            audio_info = torchaudio.info(str(channel_paths[0]))[0]
             recordings.append(Recording(
-                id=audio_idx,
+                id=session_name,
                 sources=[
                     AudioSource(
                         type='file',
-                        channels=[0],
+                        channels=[idx],
                         source=str(audio_path)
                     )
+                    for idx, audio_path in enumerate(sorted(channel_paths))
                 ],
                 sampling_rate=int(audio_info.rate),
                 num_samples=audio_info.length,
-                duration=int(audio_info.length / audio_info.rate),
+                duration=audio_info.length / audio_info.rate,
             ))
-        if len(recordings) == 0:
-            continue
         audio = RecordingSet.from_recordings(recordings)
 
         # Supervisions
         segments_by_pause = []
-        for idx in audio.recordings:
-            anotation = anotation_lists[idx]
-            for seg_idx, seg_info in enumerate(anotation):
-                for subseg_idx, subseg_info in enumerate(seg_info):
-                    duration = subseg_info.end_time - subseg_info.begin_time
-                    if duration > 0:
-                        segments_by_pause.append(SupervisionSegment(
-                            id=f'{idx}-{seg_idx}-{subseg_idx}',
-                            recording_id=idx,
-                            start=subseg_info.begin_time,
-                            duration=duration,
-                            channel=0,
-                            language='English',
-                            speaker=re.sub(r'-.*', r'', idx),
-                            text=subseg_info.text
-                        ))
+        for recording in audio:
+            for source in recording.sources:
+                # In AMI "source.channels" will always be a one-element list
+                channel = source.channels[0]
+                anotation = annotation_by_id_and_channel.get((recording.id, channel))
+                if anotation is None:
+                    logging.warning(f'No annotation found for recording "{recording.id}" channel {channel} '
+                                    f'(file {source.source})')
+                    continue
+                for seg_idx, seg_info in enumerate(anotation):
+                    for subseg_idx, subseg_info in enumerate(seg_info):
+                        duration = subseg_info.end_time - subseg_info.begin_time
+                        if duration > 0:
+                            segments_by_pause.append(SupervisionSegment(
+                                id=f'{recording.id}-{seg_idx}-{subseg_idx}',
+                                recording_id=recording.id,
+                                start=subseg_info.begin_time,
+                                duration=duration,
+                                channel=channel,
+                                language='English',
+                                speaker=subseg_info.speaker,
+                                gender=subseg_info.gender,
+                                text=subseg_info.text
+                            ))
         supervision = SupervisionSet.from_segments(segments_by_pause)
         if output_dir is not None:
             audio.to_json(output_dir / f'recordings_{part}.json')

--- a/lhotse/recipes/ami.py
+++ b/lhotse/recipes/ami.py
@@ -212,7 +212,7 @@ def prepare_ami(
         for recording in audio:
             for source in recording.sources:
                 # In AMI "source.channels" will always be a one-element list
-                channel = source.channels[0]
+                channel, = source.channels
                 anotation = annotation_by_id_and_channel.get((recording.id, channel))
                 if anotation is None:
                     logging.warning(f'No annotation found for recording "{recording.id}" channel {channel} '

--- a/lhotse/utils.py
+++ b/lhotse/utils.py
@@ -1,5 +1,6 @@
 import gzip
 import json
+import math
 import random
 import uuid
 from contextlib import contextmanager
@@ -18,7 +19,8 @@ Seconds = float
 Decibels = float
 
 INT16MAX = 32768
-EPSILON = 1e-8
+LOG_EPSILON = -100.0
+EPSILON = math.exp(LOG_EPSILON)
 
 # This is a utility that generates uuid4's and is set when the user calls
 # the ``fix_random_seed`` function.

--- a/test/cut/test_cut_mixing.py
+++ b/test/cut/test_cut_mixing.py
@@ -46,25 +46,39 @@ def test_overlay_cut_duration_and_supervisions(offset, expected_duration, except
         ]
 
 
-def test_mixed_cut_load_features():
-    expected_frame_count = 1360
+@pytest.fixture
+def mixed_feature_cut() -> MixedCut:
     cut_set = CutSet.from_json('test/fixtures/mix_cut_test/overlayed_cut_manifest.json')
     mixed_cut = cut_set['mixed-cut-id']
-    assert mixed_cut.num_frames == expected_frame_count
+    assert mixed_cut.num_frames == 1360
     assert isclose(mixed_cut.duration, 13.595)
+    return mixed_cut
 
-    feats = mixed_cut.load_features()
-    assert feats.shape[0] == expected_frame_count
+
+def test_mixed_cut_load_features_mixed(mixed_feature_cut):
+    feats = mixed_feature_cut.load_features()
+    assert feats.shape[0] == 1360
+
+
+def test_mixed_cut_load_features_unmixed(mixed_feature_cut):
+    feats = mixed_feature_cut.load_features(mixed=False)
+    assert feats.shape[0] == 2
+    assert feats.shape[1] == 1360
 
 
 @pytest.fixture
-def mixed_audio_cut():
+def mixed_audio_cut() -> MixedCut:
     cut_set = CutSet.from_json('test/fixtures/mix_cut_test/overlayed_audio_cut_manifest.json')
     mixed_cut = cut_set['mixed-cut-id']
     assert isclose(mixed_cut.duration, 14.4)
     return mixed_cut
 
 
-def test_mixed_cut_load_audio(mixed_audio_cut):
+def test_mixed_cut_load_audio_mixed(mixed_audio_cut):
     audio = mixed_audio_cut.load_audio()
     assert audio.shape == (1, 230400)
+
+
+def test_mixed_cut_load_audio_unmixed(mixed_audio_cut):
+    audio = mixed_audio_cut.load_audio(mixed=False)
+    assert audio.shape == (2, 230400)

--- a/test/cut/test_cut_set.py
+++ b/test/cut/test_cut_set.py
@@ -136,3 +136,23 @@ def test_mixed_cut_set_prefix(cut_with_relative_paths):
     for c in cut_set.with_features_path_prefix('/data'):
         for t in c.tracks:
             assert t.cut.features.storage_path == '/data/feats.llc'
+
+
+def test_mix_same_recording_channels():
+    recording = Recording('rec', sampling_rate=8000, num_samples=30 * 8000, duration=30, sources=[
+        AudioSource('file', channels=[0], source='irrelevant1.wav'),
+        AudioSource('file', channels=[1], source='irrelevant2.wav')
+    ])
+    cut_set = CutSet.from_cuts([
+        Cut('cut1', start=0, duration=30, channel=0, recording=recording),
+        Cut('cut2', start=0, duration=30, channel=1, recording=recording)
+    ])
+
+    mixed = cut_set.mix_same_recording_channels()
+    assert len(mixed) == 1
+
+    cut = mixed[0]
+    assert isinstance(cut, MixedCut)
+    assert len(cut.tracks) == 2
+    assert cut.tracks[0].cut == cut_set[0]
+    assert cut.tracks[1].cut == cut_set[1]

--- a/test/cut/test_padding_cut.py
+++ b/test/cut/test_padding_cut.py
@@ -6,9 +6,10 @@ import pytest
 from lhotse.audio import AudioSource, Recording
 from lhotse.cut import Cut, CutSet, PaddingCut
 from lhotse.features import Features
+from lhotse.utils import EPSILON, LOG_EPSILON
 
-PADDING_ENERGY = 1e-8
-PADDING_LOG_ENERGY = -18.420680743952367  # log(1e-8)
+PADDING_ENERGY = EPSILON
+PADDING_LOG_ENERGY = LOG_EPSILON
 
 
 @pytest.fixture
@@ -187,7 +188,7 @@ def test_mix_mixed_cut_with_padding_on_the_right(mixed_libri_cut, padding_cut):
     np.testing.assert_array_less(PADDING_LOG_ENERGY, mixed_feats[1603, :])  # Padding didn't start before 16.04s
 
     pre_mixed_feats = mixed_libri_cut.load_features()
-    np.testing.assert_allclose(pre_mixed_feats, mixed_feats[:1604, :], rtol=1e-2)
+    np.testing.assert_allclose(pre_mixed_feats, mixed_feats[:1604, :], rtol=1e-1)
 
 
 def test_mix_mixed_cut_with_padding_on_the_left(mixed_libri_cut, padding_cut):
@@ -261,7 +262,7 @@ def test_pad_mixed_cut(mixed_libri_cut):
     np.testing.assert_array_less(PADDING_LOG_ENERGY, mixed_feats[1603, :])  # Padding didn't start before 16.04s
 
     pre_mixed_feats = mixed_libri_cut.load_features()
-    np.testing.assert_almost_equal(pre_mixed_feats, mixed_feats[:1604, :])
+    np.testing.assert_almost_equal(pre_mixed_feats, mixed_feats[:1604, :], decimal=2)
 
 
 def test_pad_cut_set(cut_set):

--- a/test/test_feature_set.py
+++ b/test/test_feature_set.py
@@ -238,6 +238,8 @@ def test_mixer(feature_extractor, decimal, exception_expectation):
 
         np.testing.assert_almost_equal(fmix_feat, fmix_time, decimal=decimal)
 
+        assert mixer.unmixed_feats.shape == (2, 100, feature_extractor.feature_dim(sampling_rate=8000))
+
 
 def test_feature_set_prefix_path():
     features = FeatureSet.from_features([


### PR DESCRIPTION
AMI can be a great testbed for multi-channel capabilities in Lhotse, so I'm making a few improvements in its preparation sript. The idea is that we can construct a CutSet with entries like this:

<img width="401" alt="image" src="https://user-images.githubusercontent.com/15930688/94356153-1f2c0500-0059-11eb-973c-34b0df430bcc.png">

I'll still need to add tests so this is not finished.