### PR TITLE
Refactoring of features storage I/O and an initial (probably inefficient) HDF storage implementation

### DIFF
--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -12,6 +12,7 @@ from cytoolz.itertoolz import groupby
 from lhotse import WavAugmenter
 from lhotse.audio import AudioMixer, Recording, RecordingSet
 from lhotse.features import Features, FeatureExtractor, FeatureSet, FeatureMixer, create_default_feature_extractor
+from lhotse.features.io import FeaturesWriter
 from lhotse.supervision import SupervisionSegment, SupervisionSet
 from lhotse.utils import (
     EPSILON,
@@ -242,7 +243,7 @@ class Cut(CutUtilsMixin):
     def compute_and_store_features(
             self,
             extractor: FeatureExtractor,
-            output_dir: Pathlike,
+            storage: FeaturesWriter,
             augmenter: Optional[WavAugmenter] = None,
             *args,
             **kwargs
@@ -258,8 +259,8 @@ class Cut(CutUtilsMixin):
         """
         features_info = extractor.extract_from_samples_and_store(
             samples=self.load_audio(),
+            storage=storage,
             sampling_rate=self.sampling_rate,
-            output_dir=output_dir,
             offset=self.start,
             augmenter=augmenter,
         )
@@ -730,7 +731,7 @@ class MixedCut(CutUtilsMixin):
     def compute_and_store_features(
             self,
             extractor: FeatureExtractor,
-            output_dir: Pathlike,
+            storage: FeaturesWriter,
             augmenter: Optional[WavAugmenter] = None,
             mix_eagerly: bool = True
     ) -> AnyCut:
@@ -751,8 +752,8 @@ class MixedCut(CutUtilsMixin):
         if mix_eagerly:
             features_info = extractor.extract_from_samples_and_store(
                 samples=self.load_audio(),
+                storage=storage,
                 sampling_rate=self.sampling_rate,
-                output_dir=output_dir,
                 offset=0,
                 augmenter=augmenter,
             )
@@ -770,7 +771,7 @@ class MixedCut(CutUtilsMixin):
                 MixTrack(
                     cut=track.cut.compute_and_store_features(
                         extractor=extractor,
-                        output_dir=output_dir,
+                        storage=storage,
                         augmenter=augmenter,
                     ),
                     offset=track.offset,
@@ -1097,7 +1098,7 @@ class CutSet(JsonMixin, YamlMixin):
     def compute_and_store_features(
             self,
             extractor: FeatureExtractor,
-            output_dir: Pathlike,
+            storage: FeaturesWriter,
             augmenter: Optional[WavAugmenter] = None,
             executor: Optional[Any] = None,
             mix_eagerly: bool = True
@@ -1124,7 +1125,7 @@ class CutSet(JsonMixin, YamlMixin):
             return CutSet.from_cuts(
                 cut.compute_and_store_features(
                     extractor=extractor,
-                    output_dir=output_dir,
+                    storage=storage,
                     augmenter=augmenter,
                     mix_eagerly=mix_eagerly
                 )
@@ -1138,7 +1139,7 @@ class CutSet(JsonMixin, YamlMixin):
                     _extract_and_store_features_helper_fn,
                     cut,
                     extractor=extractor,
-                    output_dir=output_dir,
+                    storage=storage,
                     augmenter=augmenter,
                     mix_eagerly=mix_eagerly
                 )

--- a/lhotse/features/io.py
+++ b/lhotse/features/io.py
@@ -1,0 +1,177 @@
+from abc import ABCMeta, abstractmethod
+from functools import lru_cache
+from pathlib import Path
+from typing import Type
+
+import lilcom
+import numpy as np
+
+from lhotse.utils import Pathlike
+
+
+class FeaturesWriter(metaclass=ABCMeta):
+    @property
+    @abstractmethod
+    def name(self) -> str: ...
+
+    @property
+    @abstractmethod
+    def storage_path(self) -> str: ...
+
+    @abstractmethod
+    def write(self, key: str, value: np.ndarray) -> str: ...
+
+
+class FeaturesReader(metaclass=ABCMeta):
+    @property
+    @abstractmethod
+    def name(self) -> str: ...
+
+    @abstractmethod
+    def read(self, key: str) -> np.ndarray: ...
+
+
+READER_BACKENDS = {}
+WRITER_BACKENDS = {}
+
+
+def register_reader(cls):
+    READER_BACKENDS[cls.name] = cls
+    return cls
+
+
+def register_writer(cls):
+    WRITER_BACKENDS[cls.name] = cls
+    return cls
+
+
+def get_reader(name: str) -> Type[FeaturesReader]:
+    return READER_BACKENDS.get(name)
+
+
+def get_writer(name: str) -> Type[FeaturesWriter]:
+    return WRITER_BACKENDS.get(name)
+
+
+@register_reader
+class LilcomFilesReader(FeaturesReader):
+    name = 'lilcom_files'
+
+    def __init__(self, storage_path: Pathlike, *args, **kwargs):
+        super().__init__()
+        self.storage_path = Path(storage_path)
+
+    def read(self, key: str) -> np.ndarray:
+        """Expects key to be a valid filesystem path."""
+        with open(self.storage_path / key, 'rb') as f:
+            return lilcom.decompress(f.read())
+
+
+@register_writer
+class LilcomFilesWriter(FeaturesWriter):
+    name = 'lilcom_files'
+
+    def __init__(self, storage_path: Pathlike, tick_power: int = -5, *args, **kwargs):
+        """storage_path will point to a directory"""
+        super().__init__()
+        self.storage_path_ = Path(storage_path)
+        self.storage_path_.mkdir(parents=True, exist_ok=True)
+        self.tick_power = tick_power
+
+    @property
+    def storage_path(self) -> str:
+        return self.storage_path_
+
+    def write(self, key: str, value: np.ndarray) -> str:
+        """Expects key to be the ID of the features object."""
+        output_features_path = (self.storage_path_ / key).with_suffix('.llc')
+        serialized_feats = lilcom.compress(value, tick_power=self.tick_power)
+        with open(output_features_path, 'wb') as f:
+            f.write(serialized_feats)
+        return output_features_path.name
+
+
+@register_reader
+class NumpyFilesReader(FeaturesReader):
+    name = 'numpy_files'
+
+    def __init__(self, storage_path: Pathlike, *args, **kwargs):
+        super().__init__()
+        self.storage_path = Path(storage_path)
+
+    def read(self, key: str) -> np.ndarray:
+        """Expects key to be a valid filesystem path."""
+        return np.load(self.storage_path / key, allow_pickle=False)
+
+
+@register_writer
+class NumpyFilesWriter(FeaturesWriter):
+    name = 'numpy_files'
+
+    def __init__(self, storage_path: Pathlike, *args, **kwargs):
+        """storage_path will point to a directory"""
+        super().__init__()
+        self.storage_path_ = Path(storage_path)
+        self.storage_path_.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def storage_path(self) -> str:
+        return self.storage_path_
+
+    def write(self, key: str, value: np.ndarray) -> str:
+        """Expects key to be the ID of the features object."""
+        output_features_path = (self.storage_path_ / key).with_suffix('.npy')
+        np.save(output_features_path, value, allow_pickle=False)
+        return output_features_path.name
+
+
+@lru_cache(maxsize=10)
+def lookup_cache_or_open(storage_path: str):
+    import h5py
+    return h5py.File(storage_path, 'r')
+
+
+def close_cached_hdf_files() -> None:
+    lookup_cache_or_open.cache_clear()
+
+
+@register_reader
+class LilcomHdf5Reader(FeaturesReader):
+    name = 'lilcom_hdf5'
+
+    def __init__(self, storage_path: Pathlike, *args, **kwargs):
+        super().__init__()
+        self.hdf = lookup_cache_or_open(storage_path)
+
+    def read(self, key: str) -> np.ndarray:
+        return lilcom.decompress(self.hdf[key].value.tobytes())
+
+
+@register_writer
+class LilcomHdf5Writer(FeaturesWriter):
+    name = 'lilcom_hdf5'
+
+    def __init__(self, storage_path: Pathlike, tick_power: int = -5, *args, **kwargs):
+        super().__init__()
+        import h5py
+        self.storage_path_ = storage_path
+        self.hdf = h5py.File(storage_path, 'w')
+        self.tick_power = tick_power
+
+    @property
+    def storage_path(self) -> str:
+        return self.storage_path_
+
+    def write(self, key: str, value: np.ndarray) -> str:
+        serialized_feats = lilcom.compress(value, tick_power=self.tick_power)
+        self.hdf.create_dataset(key, data=np.void(serialized_feats))
+        return key
+
+    def close(self) -> None:
+        return self.hdf.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()


### PR DESCRIPTION
OK so I looked into HDF5 a little bit. This is a rough draft, failing tests, no comments/docs etc. just checking if this design is adequate and can work. It's mostly refactoring of the writing-to-individual-files storage method so that it's easy to plug in some other backend - this is done by introducing `FeaturesWriter` and `FeaturesReader`. They have a `name` which is written into feature manifests so during load the correct `FeaturesReader` can be instantiated (because it's decorated with `@registered_reader` decorator). Since that would lead to opening and closing handles on HDF file all the time, it is being held in an LRU cache (global program state) and can be cleared with a `close_cached_hdf_files()` call. It shouldn't lead to any problems with forking because I expect that the first call to `load_features()` will only happen after a fork (for multi-process training/dataloading), so each subprocess will open its own file handles.

The HDF5 raw-string handling documentation is not great ([they suggest putting binary data into metadata headers?!](https://docs.h5py.org/en/latest/strings.html#how-to-store-raw-binary-data)) and I might be doing something dumb. Maybe somebody more familiar with HDF can comment on that.

Below is a screenshot of usage in practice. A naive benchmark doesn't show much difference in terms of runtime on my MacBook, probably need to check on more data and on the CLSP grid which has slow I/O and will reveal any possible performance benefits. IDK when I'll have time to pick this up so feel free to comment on this in the meanwhile.

<img width="776" alt="image" src="https://user-images.githubusercontent.com/15930688/94951553-7c3d1600-04b2-11eb-81f4-a1532c85801d.png">
