### PR TITLE
Make split() a method of the manifest classes (and add CutSet support)

### DIFF
--- a/lhotse/bin/modes/manipulation.py
+++ b/lhotse/bin/modes/manipulation.py
@@ -10,8 +10,7 @@ from lhotse.bin.modes.cli_base import cli
 from lhotse.manipulation import (
     combine as combine_manifests,
     load_manifest,
-    split as split_manifest,
-    to_manifest,
+    to_manifest
 )
 from lhotse.utils import Pathlike
 
@@ -28,12 +27,13 @@ def manifest():
 @click.argument('num_splits', type=int)
 @click.argument('manifest', type=click.Path(exists=True, dir_okay=False))
 @click.argument('output_dir', type=click.Path())
-def split(num_splits: int, manifest: Pathlike, output_dir: Pathlike):
+@click.option('r', '--randomize', is_flag=True, help='Optionally randomize the sequence before splitting.')
+def split(num_splits: int, manifest: Pathlike, output_dir: Pathlike, randomize: bool):
     """Load MANIFEST, split it into NUM_SPLITS equal parts and save as separate manifests in OUTPUT_DIR. """
     output_dir = Path(output_dir)
     manifest = Path(manifest)
-    data_set = load_manifest(manifest)
-    parts = split_manifest(manifest=data_set, num_splits=num_splits)
+    any_set = load_manifest(manifest)
+    parts = any_set.split(num_splits=num_splits, randomize=randomize)
     output_dir.mkdir(parents=True, exist_ok=True)
     for idx, part in enumerate(parts):
         part.to_json(output_dir / f'{manifest.stem}.{idx + 1}.json')

--- a/lhotse/manipulation.py
+++ b/lhotse/manipulation.py
@@ -1,51 +1,16 @@
-import random
 from functools import reduce
 from itertools import chain
-from math import ceil
 from operator import add
-from typing import Any, Iterable, List, Optional, TypeVar
+from typing import Iterable, Optional, TypeVar
 
 from lhotse.audio import Recording, RecordingSet
 from lhotse.cut import Cut, CutSet, MixedCut
-from lhotse.features import Features, FeatureSet
+from lhotse.features import FeatureSet, Features
 from lhotse.supervision import SupervisionSegment, SupervisionSet
 from lhotse.utils import Pathlike, load_yaml
 
 ManifestItem = TypeVar('ManifestItem', Recording, SupervisionSegment, Features, Cut, MixedCut)
 Manifest = TypeVar('Manifest', RecordingSet, SupervisionSet, FeatureSet, CutSet)
-
-
-def split(manifest: Manifest, num_splits: int, randomize: bool = False) -> List[Manifest]:
-    """Split a manifest into `num_splits` equal parts. The element order can be randomized."""
-    num_items = len(manifest)
-    if num_splits > num_items:
-        raise ValueError(f"Cannot split manifest into more chunks ({num_splits}) than its number of items {num_items}")
-    chunk_size = int(ceil(num_items / num_splits))
-    split_indices = [(i * chunk_size, min(num_items, (i + 1) * chunk_size)) for i in range(num_splits)]
-
-    def maybe_randomize(items: Iterable[Any]) -> List[Any]:
-        items = list(items)
-        if randomize:
-            random.shuffle(items)
-        return items
-
-    if isinstance(manifest, RecordingSet):
-        contents = maybe_randomize(manifest.recordings.items())
-        return [RecordingSet(recordings=dict(contents[begin: end])) for begin, end in split_indices]
-
-    if isinstance(manifest, SupervisionSet):
-        contents = maybe_randomize(manifest.segments.items())
-        return [SupervisionSet(segments=dict(contents[begin: end])) for begin, end in split_indices]
-
-    if isinstance(manifest, FeatureSet):
-        contents = maybe_randomize(manifest.features)
-        return [FeatureSet(features=contents[begin: end]) for begin, end in split_indices]
-
-    if isinstance(manifest, CutSet):
-        contents = maybe_randomize(manifest.cuts.items())
-        return [CutSet(cuts=dict(contents[begin: end])) for begin, end in split_indices]
-
-    raise ValueError(f"Unknown type of manifest: {type(manifest)}")
 
 
 def combine(*manifests: Manifest) -> Manifest:

--- a/lhotse/test_utils.py
+++ b/lhotse/test_utils.py
@@ -1,8 +1,8 @@
 from typing import Type
 
 from lhotse.audio import Recording, RecordingSet
-from lhotse.cut import Cut
-from lhotse.features import Features, FeatureSet
+from lhotse.cut import Cut, CutSet
+from lhotse.features import FeatureSet, Features
 from lhotse.manipulation import Manifest
 from lhotse.supervision import SupervisionSegment, SupervisionSet
 from lhotse.utils import fastcopy
@@ -17,6 +17,9 @@ def DummyManifest(type_: Type, *, begin_id: int, end_id: int) -> Manifest:
     if type_ == FeatureSet:
         # noinspection PyTypeChecker
         return FeatureSet.from_features(dummy_features(idx) for idx in range(begin_id, end_id))
+    if type_ == CutSet:
+        # noinspection PyTypeChecker
+        return CutSet.from_cuts(dummy_cut(idx) for idx in range(begin_id, end_id))
 
 
 def dummy_recording(unique_id: int) -> Recording:

--- a/test/test_manipulation.py
+++ b/test/test_manipulation.py
@@ -21,6 +21,18 @@ def test_split_even(manifest_type):
 
 
 @mark.parametrize('manifest_type', [RecordingSet, SupervisionSet, FeatureSet, CutSet])
+def test_split_randomize(manifest_type):
+    manifest = DummyManifest(manifest_type, begin_id=0, end_id=100)
+    manifest_subsets = manifest.split(num_splits=2, randomize=True)
+    assert len(manifest_subsets) == 2
+    recombined_items = list(manifest_subsets[0]) + list(manifest_subsets[1])
+    assert len(recombined_items) == len(manifest)
+    # Different ordering (we convert to lists first because the *Set classes might internally
+    # re-order after concatenation, e.g. by using dict or post-init sorting)
+    assert recombined_items != list(manifest)
+
+
+@mark.parametrize('manifest_type', [RecordingSet, SupervisionSet, FeatureSet, CutSet])
 def test_split_odd(manifest_type):
     manifest = DummyManifest(manifest_type, begin_id=0, end_id=100)
     manifest_subsets = manifest.split(num_splits=3)

--- a/test/test_manipulation.py
+++ b/test/test_manipulation.py
@@ -3,40 +3,41 @@ from contextlib import nullcontext as does_not_raise
 import pytest
 from pytest import mark, raises
 
+from lhotse import CutSet
 from lhotse.audio import RecordingSet
 from lhotse.features import FeatureSet
-from lhotse.manipulation import combine, load_manifest, split
+from lhotse.manipulation import combine, load_manifest
 from lhotse.supervision import SupervisionSet
 from lhotse.test_utils import DummyManifest
 
 
-@mark.parametrize('manifest_type', [RecordingSet, SupervisionSet, FeatureSet])
+@mark.parametrize('manifest_type', [RecordingSet, SupervisionSet, FeatureSet, CutSet])
 def test_split_even(manifest_type):
     manifest = DummyManifest(manifest_type, begin_id=0, end_id=100)
-    manifest_subsets = split(manifest, num_splits=2)
+    manifest_subsets = manifest.split(num_splits=2)
     assert len(manifest_subsets) == 2
     assert manifest_subsets[0] == DummyManifest(manifest_type, begin_id=0, end_id=50)
     assert manifest_subsets[1] == DummyManifest(manifest_type, begin_id=50, end_id=100)
 
 
-@mark.parametrize('manifest_type', [RecordingSet, SupervisionSet, FeatureSet])
+@mark.parametrize('manifest_type', [RecordingSet, SupervisionSet, FeatureSet, CutSet])
 def test_split_odd(manifest_type):
     manifest = DummyManifest(manifest_type, begin_id=0, end_id=100)
-    manifest_subsets = split(manifest, num_splits=3)
+    manifest_subsets = manifest.split(num_splits=3)
     assert len(manifest_subsets) == 3
     assert manifest_subsets[0] == DummyManifest(manifest_type, begin_id=0, end_id=34)
     assert manifest_subsets[1] == DummyManifest(manifest_type, begin_id=34, end_id=68)
     assert manifest_subsets[2] == DummyManifest(manifest_type, begin_id=68, end_id=100)
 
 
-@mark.parametrize('manifest_type', [RecordingSet, SupervisionSet, FeatureSet])
+@mark.parametrize('manifest_type', [RecordingSet, SupervisionSet, FeatureSet, CutSet])
 def test_cannot_split_to_more_chunks_than_items(manifest_type):
     manifest = DummyManifest(manifest_type, begin_id=0, end_id=1)
     with pytest.raises(ValueError):
-        split(manifest, num_splits=10)
+        manifest.split(num_splits=10)
 
 
-@mark.parametrize('manifest_type', [RecordingSet, SupervisionSet, FeatureSet])
+@mark.parametrize('manifest_type', [RecordingSet, SupervisionSet, FeatureSet, CutSet])
 def test_combine(manifest_type):
     expected = DummyManifest(manifest_type, begin_id=0, end_id=200)
     combined = combine(
@@ -53,6 +54,7 @@ def test_combine(manifest_type):
         ('test/fixtures/audio.json', does_not_raise()),
         ('test/fixtures/supervision.json', does_not_raise()),
         ('test/fixtures/dummy_feats/feature_manifest.json', does_not_raise()),
+        ('test/fixtures/libri/cuts.json', does_not_raise()),
         ('test/fixtures/feature_config.yml', raises(ValueError)),
         ('no/such/path.xd', raises(FileNotFoundError)),
     ]


### PR DESCRIPTION
Mostly a discoverability improvement + fixing lack of support for CutSet. I found the option in PyCharm to sort imports alphabetically, too...